### PR TITLE
feat/fix_encoding_errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # ovos-utterance-normalizer
 
+normalizes utterances before intent parsing
+
+additionally, encoding errors are handled via [python-ftfy](https://github.com/rspeer/python-ftfy)
+
 enabled by default in [mycroft.conf](https://github.com/OpenVoiceOS/ovos-config/blob/dev/ovos_config/mycroft.conf#L129)

--- a/ovos_utterance_normalizer/__init__.py
+++ b/ovos_utterance_normalizer/__init__.py
@@ -1,9 +1,12 @@
 import string
 from typing import Optional, List
+
+import ftfy
+from ovos_plugin_manager.templates.transformers import UtteranceTransformer
+
 from ovos_utterance_normalizer.normalizer import Normalizer, CatalanNormalizer, CzechNormalizer, \
     PortugueseNormalizer, AzerbaijaniNormalizer, RussianNormalizer, EnglishNormalizer, UkrainianNormalizer, \
     GermanNormalizer
-from ovos_plugin_manager.templates.transformers import UtteranceTransformer
 
 
 class UtteranceNormalizerPlugin(UtteranceTransformer):
@@ -48,7 +51,10 @@ class UtteranceNormalizerPlugin(UtteranceTransformer):
         # 1 - expand contractions
         # 2 - original utterance
         # 3 - normalized utterance
+        fix_unicode = self.config.get("fix_encoding_errors", True)
         for u in utterances:
+            if fix_unicode:
+                u = ftfy.fix_text(u)
             norm.append(normalizer.expand_contractions(u))
             norm.append(u)
             norm.append(normalizer.normalize(u))
@@ -58,4 +64,3 @@ class UtteranceNormalizerPlugin(UtteranceTransformer):
 
         # this deduplicates the list while keeping order
         return list(dict.fromkeys(norm)), context
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ovos-utils
 quebra-frases
 ovos-plugin-manager
+ftfy


### PR DESCRIPTION
support to fixing encoding errors, see full explanation [in the docs](https://ftfy.readthedocs.io/en/latest/)

```python
ftfy.fix_text('Ã\xa0 perturber la rÃ©flexion')
'à perturber la réflexion'
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved documentation for the utterance normalizer, clarifying its purpose and functionality.
  - Added a new feature to fix encoding errors in utterances, enhancing text normalization reliability.

- **Documentation**
  - Updated README.md to include details on error handling with the `python-ftfy` library.

- **Chores**
  - Added `ftfy` as a new dependency in the requirements for improved text processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->